### PR TITLE
R1CS norm bound example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ name = "folded-falcon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ark-ff",
  "cyclotomic-rings",
  "falcon-rust",
  "latticefold",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1"
+ark-ff = "0.4.2"
 cyclotomic-rings = { git = "https://github.com/nethermindeth/latticefold", branch = "ev/r1cs-builder" }
+falcon-rust = "0.1.2"
 latticefold = { git = "https://github.com/nethermindeth/latticefold", branch = "ev/r1cs-builder" }
 stark-rings = { git = "https://github.com/NethermindEth/stark-rings.git", branch = "main", default-features = false }
 num-bigint = "0.4"
 num-traits = "0.2"
 rand = "0.8"
-falcon-rust = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ mod subring;
 pub use lfold::{LFAcc, LFComp, LFVerifier};
 pub use subring::{SplitRing, SplitRingPoly};
 
+pub const FALCON_MOD: u128 = 12289;
+
 /// Witness, signature vector components
 #[derive(Clone, Debug)]
 pub struct FalconSig {

--- a/src/subring.rs
+++ b/src/subring.rs
@@ -85,6 +85,10 @@ impl<S: PolyRing> SplitRingPoly<S> {
     pub fn into_vec(self) -> Vec<S> {
         self.0
     }
+
+    pub fn splits(&self) -> &[S] {
+        &self.0
+    }
 }
 
 impl<U: SuitableRing> SplitRing<U> {


### PR DESCRIPTION
Adds R1CS which verifies that some poly has l2 norm lower than a power of 2 bound.
Given that direct ops like `<`, `>=`, are not available in R1CS, the method employed here is through bit decomposition, where the computed l2 norm is shown to be representable using up to `log2(bound)` bits.
No roots are computed here, so we only operate on the squared norm / bound.