### PR TITLE
Add witness-free `LFComp`

### DIFF
--- a/benches/fold.rs
+++ b/benches/fold.rs
@@ -85,8 +85,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut ctx = LFVerifier::<RqNTT, DP, CS, C>::init(&comp0, &proof).unwrap();
     c.bench_function("verify", |b| {
         b.iter_batched(
-            || agg0.fold(&comp).unwrap(),
-            |proof| ctx.verify(&comp, &proof).unwrap(),
+            || (agg0.fold(&comp).unwrap(), comp.clone().into()),
+            |(proof, compv)| ctx.verify(&compv, &proof).unwrap(),
             criterion::BatchSize::SmallInput,
         )
     });

--- a/benches/fold2.rs
+++ b/benches/fold2.rs
@@ -92,8 +92,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut ctx = LFVerifier::<RqNTT, DP, CS, C>::init(&comp0, &proof).unwrap();
     c.bench_function("verify2", |b| {
         b.iter_batched(
-            || agg0.fold(&comp).unwrap(),
-            |proof| ctx.verify(&comp, &proof).unwrap(),
+            || (agg0.fold(&comp).unwrap(), comp.clone().into()),
+            |(proof, compv)| ctx.verify(&compv, &proof).unwrap(),
             criterion::BatchSize::SmallInput,
         )
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
         for _ in 0..3 {
             let comp = dummy_comp(agg.ajtai())?;
             let proof = agg.fold(&comp)?;
-            ctx.verify(&comp, &proof)?;
+            ctx.verify(&comp.into(), &proof)?;
         }
 
         Ok(())


### PR DESCRIPTION
Adds a non-accumulated LF instance, to better represent the data accessible to a verifier.