### PR TITLE
Add `FoldedRing` config

### DIFF
--- a/benches/fold.rs
+++ b/benches/fold.rs
@@ -2,8 +2,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use std::time::Duration;
 
 use folded_falcon::{
-    ConstraintScheme, LFAcc, LFComp, LFVerifier, SplitRing,
-    falcon::{Falcon512, FalconOps, FalconParams},
+    LFAcc, LFComp, LFVerifier,
+    config::{F512Frog16 as FR, FoldedRing},
+    falcon::FalconOps,
 };
 
 use anyhow::Result;
@@ -15,9 +16,7 @@ use latticefold::{
 };
 use rand::Rng;
 
-type Falcon = Falcon512;
-const K: usize = 32;
-type SplitNTT = SplitRing<RqNTT, K>;
+type Falcon = <FR as FoldedRing>::Variant;
 
 const C: usize = 38;
 const W: usize = WIT_LEN * DP::L;
@@ -40,8 +39,8 @@ fn dummy_comp(ajtai: &Ajtai) -> Result<LFComp<RqNTT, C>> {
 
     let (x, w) = Falcon::deserialize(msg, &sig, &pk);
 
-    let (r1cs, map) = SplitNTT::r1cs(1, Falcon::N, Falcon::LSB2);
-    let z = SplitNTT::z(&[(x, w)], map, Falcon::LSB2).unwrap();
+    let (r1cs, map) = FR::r1cs(1);
+    let z = FR::z(&[(x, w)], map).unwrap();
 
     let x_len = r1cs.l;
     //println!("WIT_LEN: {}", z.len() - x_len - 1);

--- a/benches/fold2.rs
+++ b/benches/fold2.rs
@@ -2,8 +2,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use std::time::Duration;
 
 use folded_falcon::{
-    ConstraintScheme, LFAcc, LFComp, LFVerifier, SplitRing,
-    falcon::{Falcon512, FalconOps, FalconParams},
+    LFAcc, LFComp, LFVerifier,
+    config::{F512Frog16 as FR, FoldedRing},
+    falcon::FalconOps,
 };
 
 use anyhow::Result;
@@ -15,9 +16,7 @@ use latticefold::{
 };
 use rand::Rng;
 
-type Falcon = Falcon512;
-const K: usize = 32;
-type SplitNTT = SplitRing<RqNTT, K>;
+type Falcon = <FR as FoldedRing>::Variant;
 
 const C: usize = 38;
 const W: usize = WIT_LEN * DP::L;
@@ -44,8 +43,8 @@ fn dummy_comp(ajtai: &Ajtai) -> Result<LFComp<RqNTT, C>> {
     let sig = Falcon::sign(msg, &sk);
     let (x1, w1) = Falcon::deserialize(msg, &sig, &pk);
 
-    let (r1cs, map) = SplitNTT::r1cs(1, Falcon::N, Falcon::LSB2);
-    let z = SplitNTT::z(&[(x0, w0), (x1, w1)], map, Falcon::LSB2).unwrap();
+    let (r1cs, map) = FR::r1cs(1);
+    let z = FR::z(&[(x0, w0), (x1, w1)], map).unwrap();
 
     let x_len = r1cs.l;
     //println!("WIT_LEN: {}", z.len() - x_len - 1);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,37 @@
+use crate::{
+    FalconInput, FalconSig,
+    falcon::{Falcon512, Falcon1024, FalconOps, FalconParams},
+    r1cs::{CSRing, ConstraintScheme, ZBuildError},
+    subring::SplitRing,
+};
+use cyclotomic_rings::rings::FrogRingNTT;
+use latticefold::arith::r1cs::{R1CS, VariableMap};
+
+/// A compatible ring for LatticeFold'ed Falcon signatures.
+pub trait FoldedRing {
+    type Ring: ConstraintScheme;
+    type Variant: FalconOps;
+
+    fn r1cs(n: usize) -> (R1CS<<Self::Ring as CSRing>::Base>, VariableMap) {
+        Self::Ring::r1cs(n, Self::Variant::N, Self::Variant::LSB2)
+    }
+
+    fn z<const N: usize>(
+        xw: &[(FalconInput<N>, FalconSig<N>)],
+        map: VariableMap,
+    ) -> Result<Vec<<Self::Ring as CSRing>::Base>, ZBuildError> {
+        Self::Ring::z(xw, map, Self::Variant::LSB2)
+    }
+}
+
+pub struct F512Frog16 {}
+impl FoldedRing for F512Frog16 {
+    type Ring = SplitRing<FrogRingNTT, 32>;
+    type Variant = Falcon512;
+}
+
+pub struct F1024Frog16 {}
+impl FoldedRing for F1024Frog16 {
+    type Ring = SplitRing<FrogRingNTT, 64>;
+    type Variant = Falcon1024;
+}


### PR DESCRIPTION
A new trait serving as a config, combining a Falcon variant (512, or 1024) with a matching ring (currently, Frog split ring with k=32, or k=64). 