### PR TITLE
Fix lift for value q-p

### DIFF
--- a/src/falcon.rs
+++ b/src/falcon.rs
@@ -146,6 +146,10 @@ impl<const N: usize> FalconPoly<N> {
         Self([0u16; N])
     }
 
+    pub fn from_coeffs(coeffs: [u16; N]) -> Self {
+        Self(coeffs)
+    }
+
     pub fn coeffs(&self) -> &[u16] {
         &self.0
     }
@@ -181,6 +185,12 @@ impl<const N: usize> FalconPoly<N> {
 impl<const N: usize> From<&Polynomial<Felt>> for FalconPoly<N> {
     fn from(p: &Polynomial<Felt>) -> Self {
         Self(core::array::from_fn(|i| p.coefficients[i].value() as u16))
+    }
+}
+
+impl<const N: usize> From<[u16; N]> for FalconPoly<N> {
+    fn from(coeffs: [u16; N]) -> Self {
+        Self::from_coeffs(coeffs)
     }
 }
 

--- a/src/subring.rs
+++ b/src/subring.rs
@@ -96,7 +96,7 @@ impl<S: OverField, const K: usize> SplitRingPoly<S, K> {
                 .as_ref()[0],
         );
         let p = <S::BaseRing as ConvertibleRing>::UnsignedInt::from(p);
-        let q = <S::BaseRing as ConvertibleRing>::UnsignedInt::from(q);
+        let qm1 = <S::BaseRing as ConvertibleRing>::UnsignedInt::from(q) - 1.into();
         let v: Vec<S> = self
             .splits()
             .iter()
@@ -107,7 +107,7 @@ impl<S: OverField, const K: usize> SplitRingPoly<S, K> {
                     .map(|c| {
                         let c_int = Into::<<S::BaseRing as ConvertibleRing>::UnsignedInt>::into(*c);
                         if c_int > mid {
-                            -S::BaseRing::from((q.clone() - c_int) / p.clone() + 1.into())
+                            -S::BaseRing::from((qm1.clone() - c_int) / p.clone() + 1.into())
                         } else {
                             S::BaseRing::from(c_int / p.clone())
                         }


### PR DESCRIPTION
Fixes a lifting issue for values `q - p` that would be wrongly represented as `p` instead of `0`.