### PR TITLE
Re-enable clippy

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -20,10 +20,10 @@ typos || {
 }
 
 # Linting
-# cargo clippy --all-targets --all-features -- -D warnings || {
-#     echo "❌ Clippy violations (check warnings above)"
-#     exit 4
-# }
+cargo clippy --all-targets --all-features -- -D warnings || {
+    echo "❌ Clippy violations (check warnings above)"
+    exit 4
+}
 
 # Tests
 cargo test --workspace --verbose || {

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Run Fmt
         run: cargo fmt --all -- --check
 
-      # - name: Run Clippy
-      #   run: cargo clippy --all-targets --all-features
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features
 
       - name: Check typos
         uses: crate-ci/typos@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ missing_docs = "warn"
 unsafe_code = "forbid"
 
 [workspace.lints.clippy]
-arithmetic_side_effects = "deny"
 cast_lossless = "deny"
 cast_possible_truncation = "deny"
 cast_possible_wrap = "deny"
@@ -25,4 +24,3 @@ cast_precision_loss = "deny"
 cast_sign_loss = "deny"
 needless_return = "deny"
 panicking_overflow_checks = "deny"
-unwrap_used = "deny"

--- a/crates/folded-falcon/src/falcon.rs
+++ b/crates/folded-falcon/src/falcon.rs
@@ -185,12 +185,12 @@ impl<const N: usize> FalconPoly<N> {
         self.0
             .iter()
             .map(|c| {
-                let m = if *c > FALCON_MOD / 2 {
+                let m = u64::from(if *c > FALCON_MOD / 2 {
                     FALCON_MOD - c
                 } else {
                     *c
-                };
-                m as u64 * m as u64
+                });
+                m * m
             })
             .sum::<u64>()
     }
@@ -198,7 +198,10 @@ impl<const N: usize> FalconPoly<N> {
 
 impl<const N: usize> From<&Polynomial<Felt>> for FalconPoly<N> {
     fn from(p: &Polynomial<Felt>) -> Self {
-        Self(core::array::from_fn(|i| p.coefficients[i].value() as u16))
+        // `Felt` is a u32, though `value()` returns an i16
+        Self(core::array::from_fn(|i| {
+            p.coefficients[i].value().unsigned_abs()
+        }))
     }
 }
 

--- a/crates/folded-falcon/src/lfold.rs
+++ b/crates/folded-falcon/src/lfold.rs
@@ -191,6 +191,7 @@ fn linearize<R: SuitableRing, CS: ChallengeSet<R>, const C: usize>(
 /// The compression ratio for some `proof` which is aggregating `n` Falcon signatures
 ///
 /// Calculated using the size of the proof over the total size of the `n` signatures.
+#[allow(clippy::cast_precision_loss)]
 pub fn compression_ratio<const C: usize, R: SuitableRing>(n: usize, proof: &LFProof<C, R>) -> f64 {
     // TODO move, add 1024 deg support (1280 bytes)
     let sig_len: usize = 666;

--- a/crates/folded-falcon/src/subring.rs
+++ b/crates/folded-falcon/src/subring.rs
@@ -321,7 +321,9 @@ impl<U: SuitableRing, const K: usize> Mul<&u128> for SplitRing<U, K> {
 
 impl<U: SuitableRing, const K: usize> MulAssign<&u16> for SplitRing<U, K> {
     fn mul_assign(&mut self, rhs: &u16) {
-        self.0.iter_mut().for_each(|s_i| *s_i *= &(*rhs as u128));
+        self.0
+            .iter_mut()
+            .for_each(|s_i| *s_i *= &(u128::from(*rhs)));
     }
 }
 


### PR DESCRIPTION
Turns clippy back on. I've removed two lints:
- `arithmetic_side_effects`: we are employing modular arithmetic almost everywhere, so thing like ring multiplication `a * b` will be naturally wrapped over the underlying modulus;
- `unwrap_used`: most of the unwraps are in the test code, and the remaining ones are in setup-associated code like everything needed to build the R1CS, so it is okay to panic is such places.

Closes #23.