### PR TITLE
Adding usage example for folded-falcon functionality

### DIFF
--- a/crates/folded-falcon/examples/usage.rs
+++ b/crates/folded-falcon/examples/usage.rs
@@ -1,0 +1,96 @@
+//! Example demonstrating the basic usage of folded-falcon.
+//!
+//! This example shows how to:
+//! 1. Create and initialize computations
+//! 2. Fold/prove computations
+//! 3. Verify folded proofs
+//! 4. Serialize and deserialize proofs
+
+use rand;
+
+use folded_falcon::{
+    LFAcc, LFComp, LFVerifier,
+    config::{F512Frog16 as FR, FoldedRing},
+    falcon::FalconOps,
+};
+
+use anyhow::Result;
+
+use cyclotomic_rings::rings::{FrogChallengeSet as CS, FrogRingNTT as RqNTT};
+use latticefold::{
+    arith::{Arith, CCCS, CCS, Witness},
+    commitment::AjtaiCommitmentScheme,
+    decomposition_parameters::DecompositionParams,
+};
+use rand::Rng;
+
+type Falcon = <FR as FoldedRing>::Variant;
+
+const C: usize = 38;
+const W: usize = WIT_LEN * DP::L;
+const WIT_LEN: usize = 3260;
+type Ajtai = AjtaiCommitmentScheme<C, W, RqNTT>;
+
+#[derive(Clone)]
+struct DP {}
+impl DecompositionParams for DP {
+    const B: u128 = 131072;
+    const L: usize = 4;
+    const B_SMALL: usize = 2;
+    const K: usize = 17;
+}
+
+fn dummy_comp(ajtai: &Ajtai) -> Result<LFComp<RqNTT, C>> {
+    let msg = b"Hello, world!";
+    let (sk, pk) = Falcon::keygen(rand::thread_rng().r#gen());
+    let sig = Falcon::sign(msg, &sk);
+
+    let (x, w) = Falcon::deserialize(msg, &sig, &pk);
+
+    let (r1cs, map) = FR::r1cs(1);
+    let z = FR::z(&[(x, w)], map).unwrap();
+
+    let x_len = r1cs.l;
+    r1cs.check_relation(&z)?;
+
+    let ccs = CCS::from_r1cs_padded(r1cs, W, DP::L);
+    ccs.check_relation(&z)?;
+
+    let wit: Witness<RqNTT> = Witness::from_w_ccs::<DP>(z[x_len + 1..].to_vec());
+    let cm_i = CCCS {
+        cm: wit.commit::<C, W, DP>(ajtai)?,
+        x_ccs: z[..x_len].to_vec(),
+    };
+
+    Ok(LFComp {
+        witness: wit,
+        cccs: cm_i,
+        ccs,
+    })
+}
+
+fn main() -> Result<()> {
+    // Step 1: Initialize Ajtai scheme and create computation
+    let mut rng = rand::thread_rng();
+    let scheme = Ajtai::rand(&mut rng);
+    let comp0 = dummy_comp(&scheme)?;
+
+    // Step 2: Initialize accumulator and get initial proof
+    let (mut acc, proof) = LFAcc::<RqNTT, DP, CS, C, W>::init(scheme, &comp0)?;
+
+    // Step 3: Create another computation
+    let comp = dummy_comp(acc.ajtai())?;
+
+    // Step 4: Fold computation into accumulator
+    let fold_proof = acc.fold(&comp)?;
+
+    // Step 5: Initialize verifier
+    let mut ctx = LFVerifier::<RqNTT, DP, CS, C>::init(&comp0, &proof)?;
+
+    // Step 6: Verify the folded proof
+    let compv = comp.clone().into();
+    let result = ctx.verify(&compv, &fold_proof)?;
+    println!("Verification result: {:?}", result);
+
+    Ok(())
+}

--- a/crates/folded-falcon/examples/usage.rs
+++ b/crates/folded-falcon/examples/usage.rs
@@ -28,17 +28,26 @@ use rand::Rng;
 
 type Falcon = <FR as FoldedRing>::Variant;
 
+// Security parameter for Ajtai commitments (length of Ajtai commitment vectors).
 const C: usize = 38;
+// Effective witness length after decomposition (original witness length * number of limbs).
 const W: usize = WIT_LEN * DP::L;
+// Original witness length before decomposition.
 const WIT_LEN: usize = 3260;
 type Ajtai = AjtaiCommitmentScheme<C, W, RqNTT>;
 
+// Struct to hold decomposition parameters.
 #[derive(Clone)]
 struct DP {}
+// Implementation of decomposition parameters for the DP struct.
 impl DecompositionParams for DP {
+    // Large modulus or bound for decomposition.
     const B: u128 = 131072;
+    // Number of levels or limbs in the decomposition.
     const L: usize = 4;
+    // Smaller base or bound used in decomposition.
     const B_SMALL: usize = 2;
+    // Parameter K for decomposition (e.g., bits per limb or security parameter).
     const K: usize = 17;
 }
 
@@ -49,6 +58,7 @@ fn dummy_comp(ajtai: &Ajtai) -> Result<LFComp<RqNTT, C>> {
 
     let (x, w) = Falcon::deserialize(msg, &sig, &pk);
 
+    // The number 1 for the FR::r1cs(1) function represents the number of signature verifications per circuit.
     let (r1cs, map) = FR::r1cs(1);
     let z = FR::z(&[(x, w)], map).unwrap();
 
@@ -105,7 +115,7 @@ fn main() -> Result<()> {
     // Step 6: Verify the folded proof
     let compv = comp.clone().into();
     ctx.verify(&compv, &fold_proof)?;
-    println!("Verification result: {:?}", ());
+    println!("Verification result: {:?}", ("Verification OK".to_string()));
 
     Ok(())
 }

--- a/crates/folded-falcon/examples/usage.rs
+++ b/crates/folded-falcon/examples/usage.rs
@@ -14,9 +14,9 @@ use folded_falcon::{
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
+use anyhow::Result;
 use latticefold::nifs::LFProof;
 use std::io::Cursor;
-use anyhow::Result;
 
 use cyclotomic_rings::rings::{FrogChallengeSet as CS, FrogRingNTT as RqNTT};
 use latticefold::{
@@ -94,8 +94,11 @@ fn main() -> Result<()> {
     // Step 4.2: Deserialize the proof
     let mut cursor = Cursor::new(&serialized_proof[..]);
     let deserialized_proof = LFProof::<C, RqNTT>::deserialize_compressed(&mut cursor)?;
-    println!("Deserialized proof size: {:?} bytes", deserialized_proof.compressed_size());
-    
+    println!(
+        "Deserialized proof size: {:?} bytes",
+        deserialized_proof.compressed_size()
+    );
+
     // Step 5: Initialize verifier
     let mut ctx = LFVerifier::<RqNTT, DP, CS, C>::init(&comp0, &proof)?;
 

--- a/crates/folded-falcon/examples/usage.rs
+++ b/crates/folded-falcon/examples/usage.rs
@@ -12,6 +12,10 @@ use folded_falcon::{
     falcon::FalconOps,
 };
 
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+
+use latticefold::nifs::LFProof;
+use std::io::Cursor;
 use anyhow::Result;
 
 use cyclotomic_rings::rings::{FrogChallengeSet as CS, FrogRingNTT as RqNTT};
@@ -82,6 +86,16 @@ fn main() -> Result<()> {
     // Step 4: Fold computation into accumulator
     let fold_proof = acc.fold(&comp)?;
 
+    // Step 4.1: Serialize the proof
+    let mut serialized_proof = Vec::new();
+    fold_proof.serialize_compressed(&mut serialized_proof)?;
+    println!("Serialized proof size: {} bytes", serialized_proof.len());
+
+    // Step 4.2: Deserialize the proof
+    let mut cursor = Cursor::new(&serialized_proof[..]);
+    let deserialized_proof = LFProof::<C, RqNTT>::deserialize_compressed(&mut cursor)?;
+    println!("Deserialized proof size: {:?} bytes", deserialized_proof.compressed_size());
+    
     // Step 5: Initialize verifier
     let mut ctx = LFVerifier::<RqNTT, DP, CS, C>::init(&comp0, &proof)?;
 

--- a/crates/folded-falcon/examples/usage.rs
+++ b/crates/folded-falcon/examples/usage.rs
@@ -6,8 +6,6 @@
 //! 3. Verify folded proofs
 //! 4. Serialize and deserialize proofs
 
-use rand;
-
 use folded_falcon::{
     LFAcc, LFComp, LFVerifier,
     config::{F512Frog16 as FR, FoldedRing},
@@ -89,8 +87,8 @@ fn main() -> Result<()> {
 
     // Step 6: Verify the folded proof
     let compv = comp.clone().into();
-    let result = ctx.verify(&compv, &fold_proof)?;
-    println!("Verification result: {:?}", result);
+    ctx.verify(&compv, &fold_proof)?;
+    println!("Verification result: {:?}", ());
 
     Ok(())
 }


### PR DESCRIPTION
# Add Basic Usage Example

Closes #28

## Description
This PR adds a basic usage example that demonstrates the core functionality of the folded-falcon library.

## Implementation Details
- Created a new example file (`examples/usage.rs`) that shows the complete workflow
- Example demonstrates:
  - Setting up Ajtai commitment scheme
  - Creating and initializing computations
  - Folding/proving with the library
  - Verifying proofs
- Added proper documentation comments

## Testing
Example can be run with:
```bash
cargo run --example usage
```

## Follow-up Work
- Could add serialization/deserialization example for proofs (marked in docstring)